### PR TITLE
[fix] 달을 넘어갈 수 있는 버튼을 클릭했을 때와 달력을 슬라이드했을 때, 년도와 월이 따로인 문제 해결

### DIFF
--- a/DontForget/app/src/main/java/com/test/dontforget/UI/MainHomeFragment/MainHomeFragment.kt
+++ b/DontForget/app/src/main/java/com/test/dontforget/UI/MainHomeFragment/MainHomeFragment.kt
@@ -436,6 +436,7 @@ class MainHomeFragment : Fragment() {
         if (isMonthMode) {
             val month =
                 binding.calendarViewMainHomeFragment.findFirstVisibleMonth()?.yearMonth ?: return
+            nowMonth = month
             binding.headerContainer.headerYearTextView.text = "${month.year}년"
             binding.headerContainer.headerMonthTextView.text = "${month.month.value}월"
         } else {


### PR DESCRIPTION
## 🔎 What type of PR is this? (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update
- [ ] Other... Please describe:

## 🐥 What need this change? 

- Related Issues :
- Closes :

## 📝 Changes 
달을 넘어갈 수 있는 버튼을 클릭했을 때와 달력을 슬라이드했을 때, 년도와 월이 따로인 문제 해결

## 📷 Screenshots, Recordings (optional)


## 👫 To Reviewers (optional)
